### PR TITLE
replace the term luminosity with luminance

### DIFF
--- a/Changes
+++ b/Changes
@@ -554,7 +554,7 @@ Imager 0.99 - 25 Jun 2014
    significantly reduce file sizes, but uses more memory and time.
    https://rt.cpan.org/Ticket/Display.html?id=94292
 
- - the autolevels filter now works on the luminosity of the image
+ - the autolevels filter now works on the luminance of the image
    rather then working per channel.  The old autolevels filter is
    still available as "autolevels_skew".
    https://rt.cpan.org/Ticket/Display.html?id=94413

--- a/lib/Imager/Filters.pod
+++ b/lib/Imager/Filters.pod
@@ -154,7 +154,7 @@ A reference of the filters follows:
 
 =item C<autolevels>
 
-Scales the luminosity of the image so that the luminosity will cover
+Scales the luminance of the image so that the luminance will cover
 the possible range for the image.  C<lsat> and C<usat> truncate the
 range by the specified fraction at the top and bottom of the range
 respectively.


### PR DESCRIPTION
- they mean different things: https://en.wikipedia.org/wiki/Luminosity vs https://en.wikipedia.org/wiki/Luminance

Just by chance I looked up the term in Wikipedia and then found the hint what the right term is on the page https://en.wikipedia.org/wiki/Luminosity_(disambiguation).

Cheers, enjoy, seasonal greetings, thank you, etc.,,,