### PR TITLE
Update the bugtracker url to point to GitHub Issues.

### DIFF
--- a/FT2/Makefile.PL
+++ b/FT2/Makefile.PL
@@ -45,8 +45,7 @@ if (eval { ExtUtils::MakeMaker->VERSION('6.46'); 1 }) {
       },
       bugtracker =>
       {
-       web => "http://rt.cpan.org/NoAuth/Bugs.html?Dist=Imager",
-       mailto => 'bug-Imager@rt.cpan.org',
+       web => "https://github.com/tonycoz/imager/issues",
       },
      },
     };

--- a/GIF/Makefile.PL
+++ b/GIF/Makefile.PL
@@ -45,8 +45,7 @@ if (eval { ExtUtils::MakeMaker->VERSION('6.46'); 1 }) {
       },
       bugtracker =>
       {
-       web => "http://rt.cpan.org/NoAuth/Bugs.html?Dist=Imager",
-       mailto => 'bug-Imager@rt.cpan.org',
+       web => "https://github.com/tonycoz/imager/issues",
       },
      },
     };

--- a/JPEG/Makefile.PL
+++ b/JPEG/Makefile.PL
@@ -45,8 +45,7 @@ if (eval { ExtUtils::MakeMaker->VERSION('6.46'); 1 }) {
       },
       bugtracker =>
       {
-       web => "http://rt.cpan.org/NoAuth/Bugs.html?Dist=Imager",
-       mailto => 'bug-Imager@rt.cpan.org',
+       web => "https://github.com/tonycoz/imager/issues",
       },
      },
     };

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -307,8 +307,7 @@ if (eval { ExtUtils::MakeMaker->VERSION('6.46'); 1 }) {
       },
       bugtracker =>
       {
-       web => "https://rt.cpan.org/Dist/Display.html?Name=Imager",
-       mailto => 'bug-Imager@rt.cpan.org',
+       web => "https://github.com/tonycoz/imager/issues",
       },
      },
     };

--- a/PNG/Makefile.PL
+++ b/PNG/Makefile.PL
@@ -45,8 +45,7 @@ if (eval { ExtUtils::MakeMaker->VERSION('6.46'); 1 }) {
       },
       bugtracker =>
       {
-       web => "http://rt.cpan.org/NoAuth/Bugs.html?Dist=Imager",
-       mailto => 'bug-Imager@rt.cpan.org',
+       web => "https://github.com/tonycoz/imager/issues",
       },
      },
     };

--- a/T1/Makefile.PL
+++ b/T1/Makefile.PL
@@ -47,8 +47,7 @@ if (eval { ExtUtils::MakeMaker->VERSION('6.46'); 1 }) {
       },
       bugtracker =>
       {
-       web => "http://rt.cpan.org/NoAuth/Bugs.html?Dist=Imager",
-       mailto => 'bug-Imager@rt.cpan.org',
+       web => "https://github.com/tonycoz/imager/issues",
       },
      },
     };

--- a/TIFF/Makefile.PL
+++ b/TIFF/Makefile.PL
@@ -52,8 +52,7 @@ if (eval { ExtUtils::MakeMaker->VERSION('6.46'); 1 }) {
       },
       bugtracker =>
       {
-       web => "http://rt.cpan.org/NoAuth/Bugs.html?Dist=Imager",
-       mailto => 'bug-Imager@rt.cpan.org',
+       web => "https://github.com/tonycoz/imager/issues",
       },
      },
     };

--- a/W32/Makefile.PL
+++ b/W32/Makefile.PL
@@ -45,8 +45,7 @@ if (eval { ExtUtils::MakeMaker->VERSION('6.46'); 1 }) {
       },
       bugtracker =>
       {
-       web => "http://rt.cpan.org/NoAuth/Bugs.html?Dist=Imager",
-       mailto => 'bug-Imager@rt.cpan.org',
+       web => "https://github.com/tonycoz/imager/issues",
       },
      },
     };


### PR DESCRIPTION
Since it is stated under the "Maintainer's Note" [^1] that bug
tracking has been moved to GitHub, it's probably better to also
updates the bugtracker info in CPAN Meta.

[^1]: https://rt.cpan.org/Dist/Display.html?Name=Imager