### PR TITLE
[PATCH] include t1tables.h for FT_Has_PS_Glyph_Names

### DIFF
--- a/FT2/freetyp2.c
+++ b/FT2/freetyp2.c
@@ -47,6 +47,9 @@ Truetype, Type1 and Windows FNT.
 #include FT_MULTIPLE_MASTERS_H
 #endif
 #endif
+#ifdef FT_TYPE1_TABLES_H
+#include FT_TYPE1_TABLES_H
+#endif
 
 static void ft2_push_message(int code);
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to Imager.
We thought you might be interested in it too.

    From 771ef328dcc4adc169b11334a3a9d940db82d250 Mon Sep 17 00:00:00 2001
    From: Niko Tyni <ntyni@debian.org>
    Date: Sun, 15 Sep 2024 09:03:46 +0100
    Subject: [PATCH] include t1tables.h for FT_Has_PS_Glyph_Names
    
    This is no longer pulled in by ftmm.h since FreeType 2.13.3
    
    Bug-Debian: https://bugs.debian.org/1081821
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libimager-perl/raw/master/debian/patches/0001-include-t1tables.h-for-FT_Has_PS_Glyph_Names.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
